### PR TITLE
Fixing create upload directory logic for controls presenting the righ…

### DIFF
--- a/repo/src/main/amp/config/alfresco/extension/templates/webscripts/alvex-upload/alvex-upload.post.js
+++ b/repo/src/main/amp/config/alfresco/extension/templates/webscripts/alvex-upload/alvex-upload.post.js
@@ -41,7 +41,7 @@ function resolveNode(reference)
 function createFolders(node, path)
 {
 	for each(x in path.split('/'))
-		if (node !== null && x.length > 0)
+		if (node !== null && x.length() > 0)
 			if(node.childByNamePath(x) === null)
 				node = node.createFolder(x);
 			else
@@ -295,7 +295,7 @@ function main()
          /**
           * Upload new file to destNode (calculated earlier) + optional subdirectory
           */
-         if (uploadDirectory !== null && uploadDirectory.length > 0)
+         if (uploadDirectory !== null && uploadDirectory.length() > 0)
          {
             if (destNode.childByNamePath(uploadDirectory) !== null || !createUploadDirectory)
 				destNode = destNode.childByNamePath(uploadDirectory);


### PR DESCRIPTION
For some reason I ignore, `String.length` is not working in rhino any more, and is giving me a pointer to a function instead of the length value.
Once I updated few calls to `.length()` the create upload directory logic is back on!
